### PR TITLE
Hooks system

### DIFF
--- a/clueslib/cluesd.py
+++ b/clueslib/cluesd.py
@@ -23,6 +23,7 @@ import time
 import schedulers
 import helpers
 import collections
+import hooks
 from configlib import _CONFIGURATION_MONITORING, _CONFIGURATION_CLUES
 from node import Node, NodeList, NodeInfo
 from request import JobList, RequestList, Request
@@ -204,6 +205,7 @@ class CluesDaemon:
         _update_enable_status_for_nodes(self._lrms_nodelist, self._db_system.get_hosts())
 
     def request(self, request):
+        hooks.HOOKS.request(request)
         self._requests_queue.append(request)
         _LOGGER.debug("new request: %s" % request)
         # cpyutils.eventloop.get_eventloop().add_event(schedulers.config_scheduling.PERIOD_SCHEDULE, "CONTROL EVENT - the request will be scheduled", stealth = True)
@@ -432,6 +434,7 @@ class CluesDaemon:
                 _LOGGER.warning("the node is already OFF or it is being powered off")
                 return True, n_id
 
+            hooks.HOOKS.pre_poweroff(n_id)
             success, nname = self._platform.power_off(n_id)
             if success:
                 if nname != n_id:
@@ -440,10 +443,14 @@ class CluesDaemon:
                     node = self._lrms_nodelist[n_id]
 
                 node.set_state(Node.POW_OFF)
+
+                hooks.HOOKS.post_poweroff(n_id, 1, nname)
                 return True, n_id
             else:
                 _LOGGER.warning("could not power off node %s. It will be considered ON, but with errors" % n_id)
                 node.set_state(Node.POW_OFF)
+                hooks.HOOKS.post_poweroff(n_id, 0, nname)
+
                 node.set_state(Node.ON_ERR)
                 return False, ""
         else:
@@ -461,6 +468,7 @@ class CluesDaemon:
                 _LOGGER.warning("the node is already ON or it is being powered on")
                 return True, n_id
             
+            hooks.HOOKS.pre_poweron(n_id)
             success, nname = self._platform.power_on(n_id)
             if success:
                 if nname != n_id:
@@ -469,10 +477,13 @@ class CluesDaemon:
                     node = self._lrms_nodelist[n_id]                
                 
                 node.set_state(Node.POW_ON)
+                hooks.HOOKS.post_poweron(n_id, 1, nname)
                 return True, n_id
             else:
                 _LOGGER.warning("could not power on node %s. It will be considered OFF, but with errors" % n_id)
                 node.set_state(Node.POW_ON)
+                hooks.HOOKS.post_poweron(n_id, 0, nname)
+
                 node.set_state(Node.OFF_ERR)
                 return False, ""
         else:

--- a/clueslib/configlib.py
+++ b/clueslib/configlib.py
@@ -28,6 +28,29 @@ except:
         })
 
 try:
+    _CONFIGURATION_HOOKS
+except:
+    _CONFIGURATION_HOOKS = cpyutils.config.Configuration("hooks",
+        {
+            "TIMEOUT_COMMAND": 180,
+            "WORKING_FOLDER": "",
+            "PRE_POWERON": "",
+            "POST_POWERON": "",
+            "PRE_POWEROFF": "",
+            "POST_POWEROFF": "",
+            "POWEREDON": "",
+            "POWEREDOFF": "",
+            "UNEXPECTED_POWERON": "",
+            "UNEXPECTED_POWEROFF": "",
+            "ONERR": "",
+            "OFFERR": "",
+            "UNKNOWN": "",
+            "IDLE": "",
+            "USED": "",
+            "REQUEST": ""
+        })
+
+try:
     _CONFIGURATION_MONITORING
 except:
     _CONFIGURATION_MONITORING = cpyutils.config.Configuration("monitoring",

--- a/clueslib/node.py
+++ b/clueslib/node.py
@@ -228,7 +228,7 @@ class Node(NodeInfo, helpers.SerializableXML):
 
         kw_updated = False
         for kw in self.keywords:
-            if kw not in other.keywords:
+            if kw not in other.keywords or self.keywords[kw] != other.keywords[kw]:
                 kw_updated = True
         for kw in other.keywords:
             if kw not in self.keywords:

--- a/cluesplugins/commandline.py
+++ b/cluesplugins/commandline.py
@@ -42,7 +42,7 @@ class powermanager(PowerManager_cmdline):
 
     def power_on(self, nname):
         if self._have_ips:
-            if nname not in self._nname_2_ip:
+            if (self._nname_2_ip is None) or (nname not in self._nname_2_ip):
                 _LOGGER.error("could not power on node because its IP address is unknown")
                 return False, None
             

--- a/etc/clues2.cfg-full-example
+++ b/etc/clues2.cfg-full-example
@@ -354,3 +354,84 @@ SLURM_PARTITION_COMMAND=/usr/local/bin/scontrol -o show partitions
 SLURM_NODES_COMMAND=/usr/local/bin/scontrol -o show nodes
 SLURM_JOBS_COMMAND=/usr/local/bin/scontrol -o show jobs
 SLURM_DEFAULT_QUEUE=wn
+
+#####################################################################################################################
+#
+# HOOKS
+#
+#####################################################################################################################
+
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+#
+# The hooks mechanism of CLUES enables to call specific applications when different events happen in the system. E.g. when a node is
+#   powered on or off. One immediate application of this system is to send an e-mail to the admin when a node has failed to be powered on.
+#
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+[hooks]
+# Folder in which the scripts are found (the scripts are being ran from this folder; clues will change the working folder to this one prior to invoke the command)
+# The commands will be generally invoked as ./<command> e.g.: ./PRE_POWERON
+# If a command is specified using an absolute path, it will be invoked using that absolute path (e.g. PRE_POWERON=/path/to/my/app will be
+#   invoked as /path/to/my/app)
+WORKING_FOLDER=/etc/clues2/scripts
+
+# Time in seconds that CLUES will wait for the commands to be executed. If this time is exceeded, the command will be killed (i.e. kill -9)
+TIMEOUT_COMMAND=180
+
+# Called prior to execute the power_on action
+#   - call: ./PRE_POWERON <node>
+# PRE_POWERON=
+
+# Called after the power_on action has been executed (e.g. ipmi poweron) and includes the information about the success or not
+#   - call: ./POST_POWERON <node> <0: failed | 1: succeded> <name of the node finally powered on>
+# POST_POWERON=
+
+# Called prior to execute the power_off action
+#   - call: ./PRE_POWEROFF <node>
+# PRE_POWEROFF=
+
+# Called after the power_off action has been executed (e.g. ipmi poweroff) and includes the information about the success or not
+#   - call: ./POST_POWEROFF <node> <0: failed | 1: succeded> <name of the node finally powered off>
+# POST_POWEROFF=
+
+# Called when the monitoring system of CLUES considers that one node is in OFF state it is detected to be in ON state. That means
+# that the state of the node has unexpectedly changed from OFF to ON
+#   - call: ./UNEXPECTED_POWERON <node>
+# UNEXPECTED_POWERON=
+
+# Called when the monitoring system of CLUES considers that one node is in ON state but it is detected to be in OFF state. That means
+# that the state of the node has unexpectedly changed from ON to OFF
+#   - call: ./UNEXPECTED_POWEROFF <node>
+# UNEXPECTED_POWEROFF=
+
+# Called when a node has been tried to be powered off, but after a time is still detected as ON
+#   - call: ./ONERR <node> <times that the node has been tried to be powered off>
+# ONERR=
+
+# Called when a node has been tried to be powered on, but after a time is still detected as OFF
+#   - call: ./OFFERR <node> <times that the node has been tried to be powered on>
+# OFFERR=
+
+# Called when a node is finally detected to be ON after it has been requested to be powered on.
+#   - call: ./POWEREDON <node>
+# POWEREDON=
+
+# Called when a node is finally detected to be OFF after it has been requested to be powered off.
+#   - call: ./POWEREDOFF <node>
+# POWEREDOFF=
+
+# Called when a node has been missing by the monitoring system of CLUES
+#   - call: ./UNKNOWN <node>
+# UNKNOWN=
+
+# Called when a node gets the idle state from the used state
+#   - call: ./IDLE <node>
+# IDLE=
+
+# Called when a node gets the used state from the idle state
+#   - call: ./USED <node>
+# USED=
+
+# Called when a request for resources is queued in the system
+#   - call: ./REQUEST <id> <slots> <memory> <tasks> <max tasks per node> <; separated specific requests expressions>
+# REQUEST=

--- a/etc/conf.d/hooks.cfg-example
+++ b/etc/conf.d/hooks.cfg-example
@@ -1,0 +1,74 @@
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+#
+# The hooks mechanism of CLUES enables to call specific applications when different events happen in the system. E.g. when a node is
+#   powered on or off. One immediate application of this system is to send an e-mail to the admin when a node has failed to be powered on.
+#
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+[hooks]
+# Folder in which the scripts are found (the scripts are being ran from this folder; clues will change the working folder to this one prior to invoke the command)
+# The commands will be generally invoked as ./<command> e.g.: ./PRE_POWERON
+# If a command is specified using an absolute path, it will be invoked using that absolute path (e.g. PRE_POWERON=/path/to/my/app will be
+#   invoked as /path/to/my/app)
+WORKING_FOLDER=/etc/clues2/scripts
+
+# Time in seconds that CLUES will wait for the commands to be executed. If this time is exceeded, the command will be killed (i.e. kill -9)
+TIMEOUT_COMMAND=180
+
+# Called prior to execute the power_on action
+#   - call: ./PRE_POWERON <node>
+# PRE_POWERON=
+
+# Called after the power_on action has been executed (e.g. ipmi poweron) and includes the information about the success or not
+#   - call: ./POST_POWERON <node> <0: failed | 1: succeded> <name of the node finally powered on>
+# POST_POWERON=
+
+# Called prior to execute the power_off action
+#   - call: ./PRE_POWEROFF <node>
+# PRE_POWEROFF=
+
+# Called after the power_off action has been executed (e.g. ipmi poweroff) and includes the information about the success or not
+#   - call: ./POST_POWEROFF <node> <0: failed | 1: succeded> <name of the node finally powered off>
+# POST_POWEROFF=
+
+# Called when the monitoring system of CLUES considers that one node is in OFF state it is detected to be in ON state. That means
+# that the state of the node has unexpectedly changed from OFF to ON
+#   - call: ./UNEXPECTED_POWERON <node>
+# UNEXPECTED_POWERON=
+
+# Called when the monitoring system of CLUES considers that one node is in ON state but it is detected to be in OFF state. That means
+# that the state of the node has unexpectedly changed from ON to OFF
+#   - call: ./UNEXPECTED_POWEROFF <node>
+# UNEXPECTED_POWEROFF=
+
+# Called when a node has been tried to be powered off, but after a time is still detected as ON
+#   - call: ./ONERR <node> <times that the node has been tried to be powered off>
+# ONERR=
+
+# Called when a node has been tried to be powered on, but after a time is still detected as OFF
+#   - call: ./OFFERR <node> <times that the node has been tried to be powered on>
+# OFFERR=
+
+# Called when a node is finally detected to be ON after it has been requested to be powered on.
+#   - call: ./POWEREDON <node>
+# POWEREDON=
+
+# Called when a node is finally detected to be OFF after it has been requested to be powered off.
+#   - call: ./POWEREDOFF <node>
+# POWEREDOFF=
+
+# Called when a node has been missing by the monitoring system of CLUES
+#   - call: ./UNKNOWN <node>
+# UNKNOWN=
+
+# Called when a node gets the idle state from the used state
+#   - call: ./IDLE <node>
+# IDLE=
+
+# Called when a node gets the used state from the idle state
+#   - call: ./USED <node>
+# USED=
+
+# Called when a request for resources is queued in the system
+#   - call: ./REQUEST <id> <slots> <memory> <tasks> <max tasks per node> <; separated specific requests expressions>
+# REQUEST=

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ class my_install(install):
 
         # We set the permissions of the configuration folder to be only readable by the one that installs CLUES (to avoid users to use commandline)
         os.chmod("/etc/clues2", 0o750)
+        distutils.archive_util.mkpath("/etc/clues2/scripts", mode=0777)
 
 
 setup(name='CLUES',
@@ -83,6 +84,8 @@ setup(name='CLUES',
             'etc/conf.d/plugin-sge.cfg-example',
             'etc/conf.d/wrapper-sge.cfg-example',
             'etc/conf.d/plugin-slurm.cfg-example',
+            'etc/conf.d/plugin-commandline.cfg-example',
+            'etc/conf.d/hooks.cfg-example',
             'etc/conf.d/plugin-wol.cfg-example',
             'etc/conf.d/plugin-ipmi.cfg-example',
             'etc/conf.d/plugin-mesos.cfg-example',

--- a/version.py
+++ b/version.py
@@ -15,4 +15,4 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-VERSION="2.1.0b"
+VERSION="2.2.0b"


### PR DESCRIPTION
This PR includes a hooks system for CLUES. Hooks are custom external scripts (or applications) that are executed when some events happen. This version includes the possibility to define the next hooks:
- Prior to execute the power_on action: ./PRE_POWERON <node>
- After the power_on action has been executed: ./POST_POWERON <node> <0: failed | 1: succeded> <name of the node finally powered on>
- Prior to execute the power_off action: ./PRE_POWEROFF <node>
- After the power_off action has been executed:
./POST_POWEROFF <node> <0: failed | 1: succeded> <name of the node finally powered off>
- The state of the node has unexpectedly changed from OFF to ON: ./UNEXPECTED_POWERON <node>
- The state of the node has unexpectedly changed from ON to OFF: ./UNEXPECTED_POWEROFF <node>
- When a node has been tried to be powered off, but after a time is still detected as ON: ./ONERR <node> <times that the node has been tried to be powered off>
- When a node has been tried to be powered on, but after a time is still detected as OFF: ./OFFERR <node> <times that the node has been tried to be powered on>
- When a node is finally detected to be ON after it has been requested to be powered on: ./POWEREDON <node>
- When a node is finally detected to be OFF after it has been requested to be powered off: ./POWEREDOFF <node>
- When a node has been missing by the monitoring system: ./UNKNOWN <node>
- When a node gets the idle state from the used state: ./IDLE <node>
- When a node gets the used state from the idle state: ./USED <node>
- When a request for resources is queued in the system: ./REQUEST <id> <slots> <memory> <tasks> <max tasks per node> <; separated specific requests expressions>
