### PR TITLE
make use of CLUES_HOST config var

### DIFF
--- a/clueslib/configlib.py
+++ b/clueslib/configlib.py
@@ -98,7 +98,7 @@ except:
             "TIMEOUT_COMMANDS":10.0,
             "CLUES_SECRET_TOKEN": "",
             "CLUES_PORT": 8000,
-            # "CLUES_HOST": "localhost",
+            "CLUES_HOST": "localhost",
             "LOG_FILE":"",
             "LOG_LEVEL":"debug",
             "LRMS_CLASS": "",

--- a/cluesserver
+++ b/cluesserver
@@ -556,7 +556,8 @@ def main_loop(custom_lrms = None, custom_power_mgr = None, callback_before_loop 
         POW_MGR = custom_power_mgr
     
     import clueslib.platform
-    server = cpyutils.rpcweb.XMLRPCServer("localhost", configserver._CONFIGURATION_GENERAL.CLUES_PORT, web_class = clues_web_server)
+    # server = cpyutils.rpcweb.XMLRPCServer("localhost", configserver._CONFIGURATION_GENERAL.CLUES_PORT, web_class = clues_web_server)
+    server = cpyutils.rpcweb.XMLRPCServer(configserver._CONFIGURATION_GENERAL.CLUES_HOST, configserver._CONFIGURATION_GENERAL.CLUES_PORT, web_class = clues_web_server)
     
     '''
     server.register_function(qsub)


### PR DESCRIPTION
var CLUES_HOST was ignored. Now it is used to start the clues server. So it is possible to use localhost (the default value), but also (e.g) 0.0.0.0